### PR TITLE
Adjusted Distance check for Interactive Objects

### DIFF
--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/bedroom_door.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/bedroom_door.prefab
@@ -110,8 +110,11 @@ MonoBehaviour:
   - NO
   hasChoice: 1
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.7
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &8571921904838669018
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/book.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/book.prefab
@@ -110,7 +110,9 @@ MonoBehaviour:
   myNextDialogue:
   - "*(The inside reads: \u201CA hundred jokes to rattle your bones!\u201D)"
   isInteracting: 0
-  maxDistance: 0.5
+  maxDistance: 0.1
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &5611276000579989406
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/closet.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/closet.prefab
@@ -109,8 +109,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.7
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &7216123764531284055
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/couch.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/couch.prefab
@@ -109,8 +109,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2
+  maxDistance: 0.7
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &2700651385088109754
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/dirty_sock.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/dirty_sock.prefab
@@ -110,8 +110,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.3
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &-5764173180879814455
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/locked_door.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/locked_door.prefab
@@ -107,8 +107,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.7
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &-370072735521215395
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/painting.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/painting.prefab
@@ -107,8 +107,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.5
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &-924621589282432858
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/papyrus.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/papyrus.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 4546427492001666985}
   - component: {fileID: 8006966756855284999}
   m_Layer: 0
-  m_Name: papyrus_sc1
+  m_Name: papyrus
   m_TagString: Interactable
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -106,8 +106,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 1.6
+  maxDistance: 0.3
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &8006966756855284999
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/pet_rock.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/pet_rock.prefab
@@ -110,8 +110,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.6
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &328674226083364320
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Prefab/GameObjects/television.prefab
+++ b/Undertale_GroupProject/Assets/Prefab/GameObjects/television.prefab
@@ -107,8 +107,11 @@ MonoBehaviour:
   - 
   hasChoice: 0
   changeChoice: 0
+  myNextDialogue: []
   isInteracting: 0
-  maxDistance: 2.2
+  maxDistance: 0.7
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!61 &913817986932049912
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Scenes/TestScene.unity
+++ b/Undertale_GroupProject/Assets/Scenes/TestScene.unity
@@ -309,7 +309,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 232296091}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8.9, y: -2.32, z: -5.862492}
+  m_LocalPosition: {x: 8.9, y: -2.32, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -507,7 +507,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 545963231}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.49, y: 1.4, z: -5.862492}
+  m_LocalPosition: {x: -2.49, y: 1.4, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -898,6 +898,8 @@ MonoBehaviour:
   myNextDialogue: []
   isInteracting: 0
   maxDistance: 2.2
+  offset: {x: 0, y: 0}
+  distToPlayer: 0
 --- !u!212 &1027400456
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Undertale_GroupProject/Assets/Scripts/gameManager.cs
+++ b/Undertale_GroupProject/Assets/Scripts/gameManager.cs
@@ -66,6 +66,8 @@ public class gameManager : MonoBehaviour
 
     [Tooltip("this is the object currently being interacted with")]
     [Header("Object in Interaction")]
+    public float distToClosestObj;
+    public GameObject closestObj;
     public interactableObj currentObj; //reference to the current object being interacted with; this will automatically change
 
     [Tooltip("adjust the maximum time before the player can interact with a new object")]
@@ -81,6 +83,7 @@ public class gameManager : MonoBehaviour
         player = (playerMovement) GameObject.FindWithTag("Player").GetComponent(typeof(playerMovement));
         playerSpawn = GameObject.FindWithTag("Player");
 
+        closestObj = GameObject.FindWithTag("Interactable");
         dialogueTextBox = canvas.transform.GetChild(0).gameObject;
         dialogueText = dialogueTextBox.transform.GetChild(0).GetComponent<Text>();
         choice1 = dialogueTextBox.transform.GetChild(1).GetComponent<Text>();
@@ -176,17 +179,17 @@ public class gameManager : MonoBehaviour
             break;
 
             case "closet":
-                index = 0;
                 dialogue = ((interactableObj)currentObj.GetComponent(typeof(interactableObj))).myNextDialogue;
                 StartCoroutine(displayDialogue());
             break;
 
             case "bedroom_papyrus":
-                swapCamera(2);
+                timeRemaining = maxTime; //begin countdown to allow player to interact again
+                runTimer = true;
                 closeDialogue();
-                index = 0;
                 dialogue.Clear();
                 dialogue.Add("Date start!");
+                swapCamera(2);
                 StartCoroutine(displayDialogue());
             break;
         }
@@ -315,7 +318,7 @@ public class gameManager : MonoBehaviour
             break;
             case 2: 
                 combatCam.enabled = true;
-                GameObject[] objs = GameObject.FindGameObjectsWithTag("InteractableObj");
+                GameObject[] objs = GameObject.FindGameObjectsWithTag("Interactable");
                 foreach (GameObject o in objs){
                     o.SetActive(false);
                 }

--- a/Undertale_GroupProject/Assets/Scripts/interactableObj.cs
+++ b/Undertale_GroupProject/Assets/Scripts/interactableObj.cs
@@ -33,6 +33,8 @@ public class interactableObj : MonoBehaviour
     [Header("Object Variables")]
     public bool isInteracting = false; //boolean holding the condition of whether the object can be interacted with
     [SerializeField] float maxDistance = 2.2f; //maximum distance to player to interact with object
+    [SerializeField] Vector2 offset;
+    [SerializeField] float distToPlayer;
     #endregion
 
     void Start(){ //auto add reference to gameManager and player
@@ -49,11 +51,13 @@ public class interactableObj : MonoBehaviour
         // if(this.name == "bedroom_door"){
         //     Debug.Log(this.name + " distance to player: " + Vector3.Distance(gameObject.GetComponent<Renderer>().bounds.center, player.transform.position));
         // }
-        if (Vector3.Distance(gameObject.GetComponent<Renderer>().bounds.center, player.transform.position) <= maxDistance){
-            Debug.Log("Player is near me: " + this.name);
+        offset = gameObject.GetComponent<Renderer>().bounds.center - player.transform.position;
+        distToPlayer = offset.sqrMagnitude;
 
+        if(gameManager.closestObj.name == this.name){
+            gameManager.distToClosestObj = distToPlayer;
             //if the object is not being interacted with, and the player presses space, interact with the object
-            if(Input.GetKeyDown(KeyCode.Return)){
+            if(distToPlayer <= maxDistance && Input.GetKeyDown(KeyCode.Return)){
                 if(!isInteracting){
                     gameManager.dialogue = myDialogue; //add this object's dialogue to the gamemanager's dialogue
                 
@@ -67,6 +71,11 @@ public class interactableObj : MonoBehaviour
                     }
                 }
             }
+        }
+        else if (gameManager.distToClosestObj > distToPlayer){
+            Debug.Log("Player is near me: " + this.name);
+            gameManager.closestObj = this.gameObject;
+            gameManager.distToClosestObj = distToPlayer;
         }
 
     }


### PR DESCRIPTION
adjusted the distance check to calculate the square of the magnitude rather than the sqrt. added a few new variables to keep track of the closest object to the player. All other objects check their distance to the player against the distance of the closest object. If their distance to the player is shorter, the closest object will change to that object. The player can only interact with the closest object.